### PR TITLE
fix usage of deprecated HttpKernelInterface::MASTER_REQUEST use ::MAIN_REQUEST instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix automated Drupal 10 compatibility fixes - Issue #3329302 by Project Update Bot
 - fix library testing path that may be inconsistent between Github Actions & GitlabCI
 - fix call to deprecated method withConsecutive() on PHPUnit
+- fix usage of deprecated HttpKernelInterface::MASTER_REQUEST use ::MAIN_REQUEST instead
 
 ## [1.0.0] - 2022-12-16
 ### Fixed

--- a/tests/src/Unit/HomepageBrowserLanguageRedirectionTest.php
+++ b/tests/src/Unit/HomepageBrowserLanguageRedirectionTest.php
@@ -111,7 +111,7 @@ class HomepageBrowserLanguageRedirectionTest extends UnitTestCase {
     $kernel = $this->prophesize(HttpKernelInterface::class);
     $request = Request::create('/', 'GET');
 
-    $event = new RequestEvent($kernel->reveal(), $request, HttpKernelInterface::MASTER_REQUEST);
+    $event = new RequestEvent($kernel->reveal(), $request, HttpKernelInterface::MAIN_REQUEST);
 
     $this->pathMatcher
       ->expects($this->once())
@@ -132,7 +132,7 @@ class HomepageBrowserLanguageRedirectionTest extends UnitTestCase {
     $kernel = $this->prophesize(HttpKernelInterface::class);
     $request = Request::create('/', 'GET');
 
-    $event = new RequestEvent($kernel->reveal(), $request, HttpKernelInterface::MASTER_REQUEST);
+    $event = new RequestEvent($kernel->reveal(), $request, HttpKernelInterface::MAIN_REQUEST);
 
     $this->pathMatcher
       ->expects($this->once())
@@ -165,7 +165,7 @@ class HomepageBrowserLanguageRedirectionTest extends UnitTestCase {
     $kernel = $this->prophesize(HttpKernelInterface::class);
     $request = Request::create('/', 'GET');
 
-    $event = new RequestEvent($kernel->reveal(), $request, HttpKernelInterface::MASTER_REQUEST);
+    $event = new RequestEvent($kernel->reveal(), $request, HttpKernelInterface::MAIN_REQUEST);
 
     $this->pathMatcher
       ->expects($this->once())
@@ -201,7 +201,7 @@ class HomepageBrowserLanguageRedirectionTest extends UnitTestCase {
     $this->request->server->set('HTTP_ACCEPT_LANGUAGE', 'fr');
     $this->request->server->set('HTTP_REFERER', 'https://www.google.ch');
 
-    $event = new RequestEvent($kernel->reveal(), $request, HttpKernelInterface::MASTER_REQUEST);
+    $event = new RequestEvent($kernel->reveal(), $request, HttpKernelInterface::MAIN_REQUEST);
 
     $currentLanguage = $this->createMock(LanguageInterface::class);
     $currentLanguage->expects($this->never())
@@ -246,7 +246,7 @@ class HomepageBrowserLanguageRedirectionTest extends UnitTestCase {
     $this->request->cookies->set('home_redirect_lang_preferred_langcode', 'en');
     $this->request->server->set('HTTP_ACCEPT_LANGUAGE', 'fr');
 
-    $event = new RequestEvent($kernel->reveal(), $request, HttpKernelInterface::MASTER_REQUEST);
+    $event = new RequestEvent($kernel->reveal(), $request, HttpKernelInterface::MAIN_REQUEST);
 
     $currentLanguage = $this->createMock(LanguageInterface::class);
     $currentLanguage->expects($this->never())
@@ -294,7 +294,7 @@ class HomepageBrowserLanguageRedirectionTest extends UnitTestCase {
     $this->request->cookies->set('home_redirect_lang_preferred_langcode', '');
     $this->request->server->set('HTTP_ACCEPT_LANGUAGE', 'fr');
 
-    $event = new RequestEvent($kernel->reveal(), $request, HttpKernelInterface::MASTER_REQUEST);
+    $event = new RequestEvent($kernel->reveal(), $request, HttpKernelInterface::MAIN_REQUEST);
 
     $currentLanguage = $this->createMock(LanguageInterface::class);
     $currentLanguage->expects($this->once())
@@ -349,7 +349,7 @@ class HomepageBrowserLanguageRedirectionTest extends UnitTestCase {
     $this->request->cookies->set('home_redirect_lang_preferred_langcode', '');
     $this->request->server->set('HTTP_ACCEPT_LANGUAGE', 'en');
 
-    $event = new RequestEvent($kernel->reveal(), $request, HttpKernelInterface::MASTER_REQUEST);
+    $event = new RequestEvent($kernel->reveal(), $request, HttpKernelInterface::MAIN_REQUEST);
 
     $currentLanguage = $this->createMock(LanguageInterface::class);
     $currentLanguage->expects($this->once())
@@ -406,7 +406,7 @@ class HomepageBrowserLanguageRedirectionTest extends UnitTestCase {
     $this->request->cookies->set('home_redirect_lang_preferred_langcode', '');
     $this->request->server->set('HTTP_ACCEPT_LANGUAGE', 'en');
 
-    $event = new RequestEvent($kernel->reveal(), $request, HttpKernelInterface::MASTER_REQUEST);
+    $event = new RequestEvent($kernel->reveal(), $request, HttpKernelInterface::MAIN_REQUEST);
 
     $currentLanguage = $this->createMock(LanguageInterface::class);
     $currentLanguage->expects($this->once())

--- a/tests/src/Unit/HomepageCookieLanguageRedirectionTest.php
+++ b/tests/src/Unit/HomepageCookieLanguageRedirectionTest.php
@@ -119,7 +119,7 @@ class HomepageCookieLanguageRedirectionTest extends UnitTestCase {
     $kernel = $this->prophesize(HttpKernelInterface::class);
     $request = Request::create('/', 'GET');
 
-    $event = new RequestEvent($kernel->reveal(), $request, HttpKernelInterface::MASTER_REQUEST);
+    $event = new RequestEvent($kernel->reveal(), $request, HttpKernelInterface::MAIN_REQUEST);
 
     $this->pathMatcher
       ->expects($this->once())
@@ -143,7 +143,7 @@ class HomepageCookieLanguageRedirectionTest extends UnitTestCase {
     $this->request->server->set('HTTP_ACCEPT_LANGUAGE', 'fr');
     $this->request->server->set('HTTP_REFERER', 'https://www.google.ch');
 
-    $event = new RequestEvent($kernel->reveal(), $request, HttpKernelInterface::MASTER_REQUEST);
+    $event = new RequestEvent($kernel->reveal(), $request, HttpKernelInterface::MAIN_REQUEST);
 
     $currentLanguage = $this->createMock(LanguageInterface::class);
     $currentLanguage->expects($this->never())
@@ -183,7 +183,7 @@ class HomepageCookieLanguageRedirectionTest extends UnitTestCase {
 
     $this->request->server->set('HTTP_ACCEPT_LANGUAGE', 'fr');
 
-    $event = new RequestEvent($kernel->reveal(), $request, HttpKernelInterface::MASTER_REQUEST);
+    $event = new RequestEvent($kernel->reveal(), $request, HttpKernelInterface::MAIN_REQUEST);
 
     $currentLanguage = $this->createMock(LanguageInterface::class);
     $currentLanguage->expects($this->never())
@@ -224,7 +224,7 @@ class HomepageCookieLanguageRedirectionTest extends UnitTestCase {
     $this->request->server->set('HTTP_ACCEPT_LANGUAGE', 'fr');
     $this->request->cookies->set('home_redirect_lang_preferred_langcode', 'fr');
 
-    $event = new RequestEvent($kernel->reveal(), $request, HttpKernelInterface::MASTER_REQUEST);
+    $event = new RequestEvent($kernel->reveal(), $request, HttpKernelInterface::MAIN_REQUEST);
 
     $currentLanguage = $this->createMock(LanguageInterface::class);
     $currentLanguage->expects($this->once())
@@ -266,7 +266,7 @@ class HomepageCookieLanguageRedirectionTest extends UnitTestCase {
     $this->request->server->set('HTTP_ACCEPT_LANGUAGE', 'fr');
     $this->request->cookies->set('home_redirect_lang_preferred_langcode', 'ru');
 
-    $event = new RequestEvent($kernel->reveal(), $request, HttpKernelInterface::MASTER_REQUEST);
+    $event = new RequestEvent($kernel->reveal(), $request, HttpKernelInterface::MAIN_REQUEST);
 
     $currentLanguage = $this->createMock(LanguageInterface::class);
     $currentLanguage->expects($this->once())
@@ -313,7 +313,7 @@ class HomepageCookieLanguageRedirectionTest extends UnitTestCase {
     $this->request->server->set('HTTP_ACCEPT_LANGUAGE', 'fr');
     $this->request->cookies->set('home_redirect_lang_preferred_langcode', 'en');
 
-    $event = new RequestEvent($kernel->reveal(), $request, HttpKernelInterface::MASTER_REQUEST);
+    $event = new RequestEvent($kernel->reveal(), $request, HttpKernelInterface::MAIN_REQUEST);
 
     $currentLanguage = $this->createMock(LanguageInterface::class);
     $currentLanguage->expects($this->once())


### PR DESCRIPTION
### 💬 Description
fix usage of deprecated HttpKernelInterface::MASTER_REQUEST use ::MAIN_REQUEST instead
